### PR TITLE
Test version of events listing page

### DIFF
--- a/calendarconfig.json
+++ b/calendarconfig.json
@@ -1,6 +1,6 @@
 ---
 ---
 {
-    "apiKey": "",
-    "calendarId": ""
+    "apiKey": "AIzaSyCG8sNlUxlUQb4_o9OGN15JSmeDKURbzR4",
+    "calendarId": "vv0uj9uhqrl6j6m0pugu90uo6c"
 }

--- a/calendarconfig.json
+++ b/calendarconfig.json
@@ -1,3 +1,5 @@
+---
+---
 {
     "apiKey": "",
     "calendarId": ""

--- a/calendarconfig.json
+++ b/calendarconfig.json
@@ -2,5 +2,5 @@
 ---
 {
     "apiKey": "AIzaSyCG8sNlUxlUQb4_o9OGN15JSmeDKURbzR4",
-    "calendarId": "vv0uj9uhqrl6j6m0pugu90uo6c"
+    "calendarId": "vv0uj9uhqrl6j6m0pugu90uo6c@group.calendar.google.com"
 }

--- a/css/events.css
+++ b/css/events.css
@@ -1,0 +1,94 @@
+    .teaserimage {
+        height:200px;
+    }
+
+    #dsa-cal-app {
+        font-family: Open Sans, MundoSans, "Helvetica Neue", Arial, Helvetica, sans-serif;
+    }
+
+    #dsa-cal-app h1 {
+        font-weight: lighter;
+        line-height: 28px;
+        padding-bottom: 0px;
+        margin-top: 40px;
+        margin-bottom: 0px;
+    }
+
+    #events-calendar {
+        width: 100%;
+        max-width: 700px;
+        margin: 0 auto;
+        padding:0;
+    }
+
+    #events-calendar li {
+        list-style-type: none;
+        padding-bottom:35px;
+        padding-top:35px;
+        margin-left:20px;
+        margin-right:20px;
+        border-bottom:1px solid #dddddd;
+    }
+
+    #events-calendar li .day {
+        font-weight:normal;
+    }
+
+    #events-calendar li .time {
+        color:#797979;
+        float:right;
+        font-size:18px;
+        text-transform: uppercase;
+        font-weight: bold;
+        padding-top:5px;
+    }
+
+    #events-calendar li .thedate {
+        color: #ec1f27;
+        font-size: 22px;
+        font-weight: lighter;
+    }
+
+    #events-calendar li .name {
+        font-weight:bold;
+        font-size:24px;
+    }
+
+    #events-calendar li .location {
+        font-style:italic;
+    }
+
+    #events-calendar li .description {
+        padding-top:10px;
+    }
+
+    #errors {
+        width: 100%;
+        max-width: 700px;
+        margin: 0 auto;
+        font-size:18px;
+        text-align:center;
+        padding-top:10px;
+    }
+
+    /* mobile */
+    @media only screen and (max-width: 800px){
+        #dsa-cal-app {
+            text-align:center;
+        }
+
+        .content {
+            padding: 50px 16px;
+        }
+        #events-calendar li .name {
+            font-weight: bold;
+            font-size: 18px;
+        }
+
+        #events-calendar li .time {
+            float: none;
+            display: block;
+            padding-top:0;
+        }
+
+    }

--- a/events.html
+++ b/events.html
@@ -89,7 +89,9 @@
                         <div class="description" itemprop="description">{{ event.description }}</div>
                     </li>
                 </ul>
-                <div id="errors" v-html="errors"></div>
+                <div id="errors" v-if="showErrors">
+                    Derp. Something went wrong- if you're seeing this, please let us know on <a href='https://www.facebook.com/NewOrleansDSA/'>Facebook</a> or the <a href='https://twitter.com/neworleansdsa'>Twitters</a>!
+                </div>
         </div>
 
 </main>

--- a/events.html
+++ b/events.html
@@ -89,9 +89,9 @@
                         <div class="description" itemprop="description">{{ event.description }}</div>
                     </li>
                 </ul>
-                <div id="errors" v-if="showErrors">
+                <!-- <div id="errors" v-if="showErrors">
                     Derp. Something went wrong- if you're seeing this, please let us know on <a href='https://www.facebook.com/NewOrleansDSA/'>Facebook</a> or the <a href='https://twitter.com/neworleansdsa'>Twitters</a>!
-                </div>
+                </div> -->
         </div>
 
 </main>

--- a/events.html
+++ b/events.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <!-- (1) Optimize for mobile versions: http://goo.gl/EOpFl -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    
+    <!-- (1) force latest IE rendering engine: bit.ly/1c8EiC9 -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <title>DSA New Orleans - Events</title>
+    <meta name="description" content="" />
+
+    <meta name="HandheldFriendly" content="True" />
+    <meta name="MobileOptimized" content="320" />
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="DSA New Orleans">
+    <meta name="twitter:description" content="">
+    <meta name="twitter:site" content="http://mark-read.info">
+    <meta name="twitter:creator" content="@MarkReadM">
+    <meta name="google-site-verification" content="">
+    <meta property="fb:admins" content="">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="DSA New Orleans">
+    <meta property="og:description" content="">
+
+    <link rel="icon" type="image/x-icon" href="/img/logo.png" />
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" />
+    <link rel="stylesheet" href="/js/styles/obsidian.css">
+    <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Linux+Libertine:400,400i,700,700i/Open+Sans:400,400i,700,700i">
+    <link href="//netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
+    <link rel="stylesheet" type="text/css" media="screen" href="/css/main.css" />
+    <link rel="stylesheet" type="text/css" media="print" href="/css/print.css" />
+    <link rel="stylesheet" type="text/css" media="screen" href="/css/solarized.css" />
+    <!--
+    <link href="/css/commented.min.css" rel="stylesheet">
+    -->
+    <script src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
+    <style>
+        .post-content a,
+        .post-content a:active {
+            color: #ec1f27;
+        }
+        .post-content a:visited {
+            color: #d3363b;
+        }
+        .post-content a:hover,
+        .post-content a:focus {
+            color: #000;
+        }
+    </style>
+</head>
+<body class="">
+    <nav class="champagne-nav">
+        <a class="champagne-nav__item" href="/">Home</a>
+        <a class="champagne-nav__item" href="/events.html">Events</a>
+        <a class="champagne-nav__item" href="https://goo.gl/forms/PGwzoWr7tdQqqR3w1">Sign Up</a>
+        <a class="champagne-nav__item champagne-nav__item--social" href="https://twitter.com/neworleansdsa"><span class="sr-only">Twitter</span><i class="fa fa-twitter"></i></a>
+        <a class="champagne-nav__item champagne-nav__item--social" href="https://facebook.com/neworleansdsa"><span class="sr-only">Facebook</span><i class="fa fa-facebook"></i></a>
+    </nav>
+    
+
+<div class="teaserimage">
+    <div class="teaserimage-image" style="background-image: url(/img/teaser.png)">
+        Teaser Image
+    </div>
+</div>
+<script src="/js/teaser.js"></script>
+
+<main class="content" role="main">
+
+        <div id="dsa-cal-app">
+                <h1>Upcoming Events</h1>
+                <ul id="events-calendar">
+                    <li v-for="(event, index) in calevents" itemscope itemtype="http://schema.org/Event">
+                        <meta itemprop="startDate" content="{{event.theStart}}">
+                        <div v-for="thedate in getPrettyDate(event.theStart)" class="thedate">
+                            <span class="day">{{ thedate.day }}</span> 
+                            <span class="month">{{ thedate.month }}</span>
+                            <span class="date"> {{ thedate.date }}</span>
+                            <span class="time"> {{ thedate.time }} {{ thedate.ampm}}</span>
+                        </div>
+                                               
+                        <div itemprop="name" class="name">{{ event.summary }}</div>
+                        <div class="location">{{ event.location }}</div>
+                        <div class="description" itemprop="description">{{ event.description }}</div>
+                    </li>
+                </ul>
+                <div id="errors" v-html="errors"></div>
+        </div>
+
+</main>
+
+<footer class="site-footer">
+    <a class="subscribe icon-feed" href="/rss.xml"><span class="tooltip"> Subscribe!</span></a>
+    <div class="inner">
+         <section class="copyright">All content copyright <a href="//">DSA New Orleans</a> &copy; 2017 &bull; All rights reserved.</section>
+         <section class="poweredby">Proudly published with <a class="icon-hexo" href="http://hexo.io"> Hexo</a></section>
+    </div>
+</footer>
+
+    <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.7.0/moment.min.js"></script>
+    
+    <!-- Calendar-specific stuff -->
+    <link rel="stylesheet" type="text/css" media="screen" href="/css/events.css" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.4.2/vue.min.js"></script>
+    <script type="text/javascript" src="/js/events.js"></script>
+
+</body>
+</html>

--- a/events.html
+++ b/events.html
@@ -81,7 +81,7 @@
                             <span class="day">{{ event.prettyDate.day }}</span> 
                             <span class="month">{{ event.prettyDate.month }}</span>
                             <span class="date"> {{ event.prettyDate.date }}</span>
-                            <span class="time"> {{ event.prettyDate.time }} {{ thedate.prettyDate.ampm }}</span>
+                            <span class="time"> {{ event.prettyDate.time }} {{ event.prettyDate.ampm }}</span>
                         </div>
                                                
                         <div itemprop="name" class="name">{{ event.summary }}</div>

--- a/events.html
+++ b/events.html
@@ -75,13 +75,16 @@
         <div id="dsa-cal-app">
                 <h1>Upcoming Events</h1>
                 <ul id="events-calendar">
-                    <li v-for="(event, index) in calevents" itemscope itemtype="http://schema.org/Event">
+                    <li v-for="(event, index) in calEvents" itemscope itemtype="http://schema.org/Event">
                         <meta itemprop="startDate" content="{{event.theStart}}">
                         <div class="thedate">
-                            <span class="day">{{ event.prettyDate.day }}</span> 
-                            <span class="month">{{ event.prettyDate.month }}</span>
-                            <span class="date"> {{ event.prettyDate.date }}</span>
-                            <span class="time"> {{ event.prettyDate.time }} {{ event.prettyDate.ampm }}</span>
+                            <span class="day">{{ event.prettyStartTime.day }}</span> 
+                            <span class="month">{{ event.prettyStartTime.month }}</span>
+                            <span class="date"> {{ event.prettyStartTime.date }}</span>
+                            <span class="time" v-if="event.hasStartTime"> 
+                                <span> {{ event.prettyStartTime.time }} {{ event.prettyStartTime.ampm }} </span>
+                                <span v-if="event.hasEndTime"> - {{ event.prettyEndTime.time }} {{ event.prettyEndTime.ampm }} </span>
+                            </span>
                         </div>
                                                
                         <div itemprop="name" class="name">{{ event.summary }}</div>
@@ -89,9 +92,9 @@
                         <div class="description" itemprop="description">{{ event.description }}</div>
                     </li>
                 </ul>
-                <!-- <div id="errors" v-if="showErrors">
+                <div id="errors" v-if="showErrors">
                     Derp. Something went wrong- if you're seeing this, please let us know on <a href='https://www.facebook.com/NewOrleansDSA/'>Facebook</a> or the <a href='https://twitter.com/neworleansdsa'>Twitters</a>!
-                </div> -->
+                </div>
         </div>
 
 </main>

--- a/events.html
+++ b/events.html
@@ -77,11 +77,11 @@
                 <ul id="events-calendar">
                     <li v-for="(event, index) in calevents" itemscope itemtype="http://schema.org/Event">
                         <meta itemprop="startDate" content="{{event.theStart}}">
-                        <div v-for="thedate in getPrettyDate(event.theStart)" class="thedate">
-                            <span class="day">{{ thedate.day }}</span> 
-                            <span class="month">{{ thedate.month }}</span>
-                            <span class="date"> {{ thedate.date }}</span>
-                            <span class="time"> {{ thedate.time }} {{ thedate.ampm}}</span>
+                        <div class="thedate">
+                            <span class="day">{{ thedate.prettyDate.day }}</span> 
+                            <span class="month">{{ thedate.prettyDate.month }}</span>
+                            <span class="date"> {{ thedate.prettyDate.date }}</span>
+                            <span class="time"> {{ thedate.prettyDate.time }} {{ thedate.prettyDate.ampm }}</span>
                         </div>
                                                
                         <div itemprop="name" class="name">{{ event.summary }}</div>

--- a/events.html
+++ b/events.html
@@ -78,10 +78,10 @@
                     <li v-for="(event, index) in calevents" itemscope itemtype="http://schema.org/Event">
                         <meta itemprop="startDate" content="{{event.theStart}}">
                         <div class="thedate">
-                            <span class="day">{{ thedate.prettyDate.day }}</span> 
-                            <span class="month">{{ thedate.prettyDate.month }}</span>
-                            <span class="date"> {{ thedate.prettyDate.date }}</span>
-                            <span class="time"> {{ thedate.prettyDate.time }} {{ thedate.prettyDate.ampm }}</span>
+                            <span class="day">{{ event.prettyDate.day }}</span> 
+                            <span class="month">{{ event.prettyDate.month }}</span>
+                            <span class="date"> {{ event.prettyDate.date }}</span>
+                            <span class="time"> {{ event.prettyDate.time }} {{ thedate.prettyDate.ampm }}</span>
                         </div>
                                                
                         <div itemprop="name" class="name">{{ event.summary }}</div>

--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
 <body class="">
     <nav class="champagne-nav">
         <a class="champagne-nav__item" href="/">Home</a>
+        <a class="champagne-nav__item" href="/events.html">Events</a>
         <a class="champagne-nav__item" href="https://goo.gl/forms/PGwzoWr7tdQqqR3w1">Sign Up</a>
         <a class="champagne-nav__item champagne-nav__item--social" href="https://twitter.com/neworleansdsa"><span class="sr-only">Twitter</span><i class="fa fa-twitter"></i></a>
         <a class="champagne-nav__item champagne-nav__item--social" href="https://facebook.com/neworleansdsa"><span class="sr-only">Facebook</span><i class="fa fa-facebook"></i></a>

--- a/js/events.js
+++ b/js/events.js
@@ -1,66 +1,65 @@
-var mykey = 'AIzaSyAHAKS3oeDgnsknND2GVeCTiDgKqy7uMrw'; // sumthin like Gtg-rtZdsreUr_fLfhgPfgff
-var calendarid = 'nbq9d5kvi60fj6m34ml77a6hdc@group.calendar.google.com'; // looks like nbq9d5kvi60fj6m34ml77a6hdc@group.calendar.google.com
-
-var caldata = "";
-
-new Vue({
-    el: '#dsa-cal-app',
-    data: {
-        calevents: '',
-        errors:''
-    },
-    methods: {
-        getPrettyDate: function(uglydateTime){
-            prettyPattern = "dddd, MMMM Do YYYY, h:mm a";
-            
-            if(uglydateTime == undefined){
-                console.log("derp");
-            }
-            var theMoment = moment(uglydateTime);
-            // this is maybe the not most rational way to do this <_<
-            var day = theMoment.clone().format("dddd");
-            var month = theMoment.clone().format("MMMM");
-            var date = theMoment.clone().format("Do");
-            var year = theMoment.clone().format("YYYY");
-            var time = theMoment.clone().format("h:mm");
-            var ampm = theMoment.clone().format("a");
-            var output = [{day,month,date,year,time,ampm}];
-            return output;
-        }
-    },
-    mounted: function() {
-        var th = this;
-        var today = new Date();
-        $.ajax({
-            type: 'GET',
-            url: encodeURI('https://www.googleapis.com/calendar/v3/calendars/' + calendarid+ '/events?key=' + mykey +'&timeMin='+ today.toISOString()), //only get upcoming events
-            dataType: 'json',
-            success: function (response) {
-                var theEvents = response.items;
-                console.log(theEvents);
-
-                // all day events don't have a dateTime, so will screw up the chonological order- so if there's no dateTime, just use date
-                theEvents.forEach(function(event){
-                    if(event.start.dateTime == undefined){
-                        console.log("no dateTime for "+event.summary+", using date");
-                        event.theStart = event.start.date;
-                    } else {
-                        event.theStart = event.start.dateTime;
-                    }
-                });
-                
-                theEvents.sort(function(a,b){ // sort to make sure the events are in chron order
-                    a = new Date(a.theStart);
-                    b = new Date(b.theStart);
-                    return a<b ? -1 : a>b ? 1 : 0;}
-                );
-                
-                th.calevents = theEvents;
-            },
-            error: function (response) {
-                th.errors = "Derp. Something went wrong- if you're seeing this, please let us know on <a href='https://www.facebook.com/NewOrleansDSA/'>Facebook</a> or the <a href='https://twitter.com/neworleansdsa'>Twitters</a>!"; 
-            }
-        });
-    }
+(() => {
     
-})
+    const createVm = (config) => {
+        const _vm = {
+            el: '#dsa-cal-app',
+            data: {
+                calevents: '',
+                errors:''
+            },
+            methods: {
+                getPrettyDate: (uglydateTime) => {
+                    const prettyPattern = "dddd, MMMM Do YYYY, h:mm a";
+                    
+                    if(uglydateTime == undefined){
+                        console.log("derp");
+                    }
+                    const theMoment = moment(uglydateTime);
+                    // this is maybe the not most rational way to do this <_<
+                    const day = theMoment.clone().format("dddd");
+                    const month = theMoment.clone().format("MMMM");
+                    const date = theMoment.clone().format("Do");
+                    const year = theMoment.clone().format("YYYY");
+                    const time = theMoment.clone().format("h:mm");
+                    const ampm = theMoment.clone().format("a");
+                    const output = {day,month,date,year,time,ampm};
+                    return output;
+                }
+            },
+            mounted: () => {
+                const today = new Date();
+                // only get upcoming events:
+                const uri = `https://www.googleapis.com/calendar/v3/calendars/${config.calendarId}/events?key=${config.apiKey}&timeMin=${today.toISOString()}`;
+                try {
+                    const response = await fetch(uri);
+                }
+                catch (r) {
+                    vm.errors = "Derp. Something went wrong- if you're seeing this, please let us know on <a href='https://www.facebook.com/NewOrleansDSA/'>Facebook</a> or the <a href='https://twitter.com/neworleansdsa'>Twitters</a>!";
+                    return;
+                }
+        
+                const theEvents = (await response.json()).items;
+                
+                _vm.calevents = theEvents
+                    // all day events don't have a dateTime, so will screw up the chonological order- so if there's no dateTime, just use date
+                    .map((e) => {
+                        const theStart = (e.start.dateTime == undefined) ? e.start.date : e.start.dateTime;
+                        return {...e, theStart, prettyDate: _vm.getPrettyDate(e)};
+                    })
+                    // sort to make sure the events are in chron order
+                    .sort((a,b) => { 
+                        const a = new Date(a.theStart);
+                        const b = new Date(b.theStart);
+                        return a<b ? -1 : a>b ? 1 : 0;
+                    });
+            }
+        };
+
+        return _vm;
+    };
+    
+    const configResponse = await fetch("/calendarconfig.json");
+    const config = await configResponse.json();
+
+    new Vue(createVm(config));
+})();

--- a/js/events.js
+++ b/js/events.js
@@ -1,5 +1,19 @@
 (() => {
     
+    const getPrettyDate = (uglydateTime) => {
+        const prettyPattern = "dddd, MMMM Do YYYY, h:mm a";
+        const theMoment = moment(uglydateTime);
+        
+        const day = theMoment.clone().format("dddd");
+        const month = theMoment.clone().format("MMMM");
+        const date = theMoment.clone().format("Do");
+        const year = theMoment.clone().format("YYYY");
+        const time = theMoment.clone().format("h:mm");
+        const ampm = theMoment.clone().format("a");
+        const output = {day,month,date,year,time,ampm};
+        return output;
+    };
+
     const createVm = (config) => {
         const _vm = {
             el: '#dsa-cal-app',
@@ -8,23 +22,7 @@
                 errors:''
             },
             methods: {
-                getPrettyDate: (uglydateTime) => {
-                    const prettyPattern = "dddd, MMMM Do YYYY, h:mm a";
-                    
-                    if(uglydateTime == undefined){
-                        console.log("derp");
-                    }
-                    const theMoment = moment(uglydateTime);
-                    // this is maybe the not most rational way to do this <_<
-                    const day = theMoment.clone().format("dddd");
-                    const month = theMoment.clone().format("MMMM");
-                    const date = theMoment.clone().format("Do");
-                    const year = theMoment.clone().format("YYYY");
-                    const time = theMoment.clone().format("h:mm");
-                    const ampm = theMoment.clone().format("a");
-                    const output = {day,month,date,year,time,ampm};
-                    return output;
-                }
+                
             },
             mounted: () => {
                 const today = new Date();
@@ -44,7 +42,7 @@
                     // all day events don't have a dateTime, so will screw up the chonological order- so if there's no dateTime, just use date
                     .map((e) => {
                         const theStart = (e.start.dateTime == undefined) ? e.start.date : e.start.dateTime;
-                        return {...e, theStart, prettyDate: _vm.getPrettyDate(e)};
+                        return {...e, theStart, prettyDate: getPrettyDate(e)};
                     })
                     // sort to make sure the events are in chron order
                     .sort((a,b) => { 

--- a/js/events.js
+++ b/js/events.js
@@ -26,7 +26,7 @@
             },
             //showErrors:false,
             mounted: async () => {
-                const today = moment(new Date()).add("month", -1);
+                const today = moment(new Date());
                 // only get upcoming events:
                 const uri = `https://www.googleapis.com/calendar/v3/calendars/${config.calendarId}/events?key=${config.apiKey}&timeMin=${today.toISOString()}`;
                 

--- a/js/events.js
+++ b/js/events.js
@@ -1,4 +1,4 @@
-(() => {
+(async () => {
     
     const getPrettyDate = (uglydateTime) => {
         const prettyPattern = "dddd, MMMM Do YYYY, h:mm a";
@@ -24,12 +24,15 @@
             methods: {
                 
             },
-            mounted: () => {
+            //showErrors:false,
+            mounted: async () => {
                 const today = new Date();
                 // only get upcoming events:
                 const uri = `https://www.googleapis.com/calendar/v3/calendars/${config.calendarId}/events?key=${config.apiKey}&timeMin=${today.toISOString()}`;
+                
+                let response;
                 try {
-                    const response = await fetch(uri);
+                    response = await fetch(uri);
                 }
                 catch (r) {
                     vm.errors = "Derp. Something went wrong- if you're seeing this, please let us know on <a href='https://www.facebook.com/NewOrleansDSA/'>Facebook</a> or the <a href='https://twitter.com/neworleansdsa'>Twitters</a>!";
@@ -45,9 +48,9 @@
                         return {...e, theStart, prettyDate: getPrettyDate(e)};
                     })
                     // sort to make sure the events are in chron order
-                    .sort((a,b) => { 
-                        const a = new Date(a.theStart);
-                        const b = new Date(b.theStart);
+                    .sort((x,y) => { 
+                        const a = new Date(x.theStart);
+                        const b = new Date(y.theStart);
                         return a<b ? -1 : a>b ? 1 : 0;
                     });
             }
@@ -56,7 +59,14 @@
         return _vm;
     };
     
-    const configResponse = await fetch("/calendarconfig.json");
+    let configResponse
+    
+    try {
+        configResponse = await fetch("/calendarconfig.json");
+    }
+    catch(e){
+        console.log(e);
+    }
     const config = await configResponse.json();
 
     new Vue(createVm(config));

--- a/js/events.js
+++ b/js/events.js
@@ -1,16 +1,16 @@
 (async () => {
     
     const getPrettyDate = (uglydateTime) => {
-        const prettyPattern = "dddd, MMMM Do YYYY, h:mm a";
         const theMoment = moment(uglydateTime);
         
-        const day = theMoment.clone().format("dddd");
-        const month = theMoment.clone().format("MMMM");
-        const date = theMoment.clone().format("Do");
-        const year = theMoment.clone().format("YYYY");
-        const time = theMoment.clone().format("h:mm");
-        const ampm = theMoment.clone().format("a");
+        const day = theMoment.format("dddd");
+        const month = theMoment.format("MMMM");
+        const date = theMoment.format("Do");
+        const year = theMoment.format("YYYY");
+        const time = theMoment.format("h:mm");
+        const ampm = theMoment.format("a");
         const output = {day,month,date,year,time,ampm};
+        
         return output;
     };
 
@@ -18,7 +18,7 @@
         const _vm = {
             el: '#dsa-cal-app',
             data: {
-                calevents: [],
+                calEvents: [],
                 showErrors:false,
             },
             methods: {
@@ -45,11 +45,22 @@
 
                 const theEvents = (await response.json()).items;
                 
-                _vm.data.calevents = theEvents
+                _vm.data.calEvents = theEvents
                     // all day events don't have a dateTime, so will screw up the chonological order- so if there's no dateTime, just use date
                     .map((e) => {
-                        const theStart = (e.start.dateTime == undefined) ? e.start.date : e.start.dateTime;
-                        return {...e, theStart, prettyDate: getPrettyDate(e)};
+                        const hasStartTime = e.start.dateTime != undefined;
+                        const startTime = (hasStartTime) ? e.start.dateTime : e.start.date;
+                        
+                        const hasEndTime = e.end.dateTime != undefined 
+                        const endTime = (hasEndTime) ? e.end.dateTime : e.end.date;
+                        
+                        return {
+                            ...e, 
+                            hasStartTime,
+                            hasEndTime,
+                            prettyStartTime: getPrettyDate(startTime),
+                            prettyEndTime: getPrettyDate(endTime),
+                        };
                     })
                     // sort to make sure the events are in chron order
                     .sort((x,y) => { 

--- a/js/events.js
+++ b/js/events.js
@@ -18,15 +18,15 @@
         const _vm = {
             el: '#dsa-cal-app',
             data: {
-                calevents: '',
-                errors:''
+                calevents: [],
+                showErrors:false,
             },
             methods: {
                 
             },
             //showErrors:false,
             mounted: async () => {
-                const today = new Date();
+                const today = moment(new Date()).add("month", -1);
                 // only get upcoming events:
                 const uri = `https://www.googleapis.com/calendar/v3/calendars/${config.calendarId}/events?key=${config.apiKey}&timeMin=${today.toISOString()}`;
                 
@@ -35,13 +35,17 @@
                     response = await fetch(uri);
                 }
                 catch (r) {
-                    vm.errors = "Derp. Something went wrong- if you're seeing this, please let us know on <a href='https://www.facebook.com/NewOrleansDSA/'>Facebook</a> or the <a href='https://twitter.com/neworleansdsa'>Twitters</a>!";
+                    _vm.showErrors = true;
                     return;
                 }
         
+                if (!response.ok) {
+                    return _vm.showErrors = true 
+                }
+
                 const theEvents = (await response.json()).items;
                 
-                _vm.calevents = theEvents
+                _vm.data.calevents = theEvents
                     // all day events don't have a dateTime, so will screw up the chonological order- so if there's no dateTime, just use date
                     .map((e) => {
                         const theStart = (e.start.dateTime == undefined) ? e.start.date : e.start.dateTime;
@@ -69,5 +73,8 @@
     }
     const config = await configResponse.json();
 
-    new Vue(createVm(config));
+    const vm = createVm(config);
+
+    window.vm = vm;
+    new Vue(vm);
 })();

--- a/js/events.js
+++ b/js/events.js
@@ -1,0 +1,66 @@
+var mykey = 'AIzaSyAHAKS3oeDgnsknND2GVeCTiDgKqy7uMrw'; // sumthin like Gtg-rtZdsreUr_fLfhgPfgff
+var calendarid = 'nbq9d5kvi60fj6m34ml77a6hdc@group.calendar.google.com'; // looks like nbq9d5kvi60fj6m34ml77a6hdc@group.calendar.google.com
+
+var caldata = "";
+
+new Vue({
+    el: '#dsa-cal-app',
+    data: {
+        calevents: '',
+        errors:''
+    },
+    methods: {
+        getPrettyDate: function(uglydateTime){
+            prettyPattern = "dddd, MMMM Do YYYY, h:mm a";
+            
+            if(uglydateTime == undefined){
+                console.log("derp");
+            }
+            var theMoment = moment(uglydateTime);
+            // this is maybe the not most rational way to do this <_<
+            var day = theMoment.clone().format("dddd");
+            var month = theMoment.clone().format("MMMM");
+            var date = theMoment.clone().format("Do");
+            var year = theMoment.clone().format("YYYY");
+            var time = theMoment.clone().format("h:mm");
+            var ampm = theMoment.clone().format("a");
+            var output = [{day,month,date,year,time,ampm}];
+            return output;
+        }
+    },
+    mounted: function() {
+        var th = this;
+        var today = new Date();
+        $.ajax({
+            type: 'GET',
+            url: encodeURI('https://www.googleapis.com/calendar/v3/calendars/' + calendarid+ '/events?key=' + mykey +'&timeMin='+ today.toISOString()), //only get upcoming events
+            dataType: 'json',
+            success: function (response) {
+                var theEvents = response.items;
+                console.log(theEvents);
+
+                // all day events don't have a dateTime, so will screw up the chonological order- so if there's no dateTime, just use date
+                theEvents.forEach(function(event){
+                    if(event.start.dateTime == undefined){
+                        console.log("no dateTime for "+event.summary+", using date");
+                        event.theStart = event.start.date;
+                    } else {
+                        event.theStart = event.start.dateTime;
+                    }
+                });
+                
+                theEvents.sort(function(a,b){ // sort to make sure the events are in chron order
+                    a = new Date(a.theStart);
+                    b = new Date(b.theStart);
+                    return a<b ? -1 : a>b ? 1 : 0;}
+                );
+                
+                th.calevents = theEvents;
+            },
+            error: function (response) {
+                th.errors = "Derp. Something went wrong- if you're seeing this, please let us know on <a href='https://www.facebook.com/NewOrleansDSA/'>Facebook</a> or the <a href='https://twitter.com/neworleansdsa'>Twitters</a>!"; 
+            }
+        });
+    }
+    
+})

--- a/js/teaser.js
+++ b/js/teaser.js
@@ -1,12 +1,11 @@
-(function ($) {
-    "use strict";
+(($) => {
 
-    $(document).ready(function(){
+    $(document).ready(() => {
 
-        var $window = $(window),
-            $image = $('.teaserimage-image');
-        $window.on('scroll', function() {
-            var top = $window.scrollTop();
+        const $window = $(window);
+        const $image = $('.teaserimage-image');
+        $window.on('scroll', () => {
+            const top = $window.scrollTop();
 
             if (top < 0 || top > 1500) { return; }
             $image
@@ -17,5 +16,5 @@
 
     });
 
-}(jQuery));
+})(jQuery);
 

--- a/themes/calendarconfig.json
+++ b/themes/calendarconfig.json
@@ -1,0 +1,4 @@
+{
+    "apiKey": "",
+    "calendarId": ""
+}


### PR DESCRIPTION
hey yall not sure the workflow here, but I went ahead and wrapped the events listing widget thing in the current site header/footer. To avoid reinventing the wheel I just did this hardcoded w/o haxo, so when it goes live the main page will need to be rebuilt with a new 'events' menu item. 

Right now it's just set to pull some dummy data from a calendar I'm subscribed to- whatever google calendar it _should_ pull from needs to be set to public and have an api key generated and added to the script (instructions are here: https://bitbucket.org/trey_daniel/dsa-cal-widget). Figured we could pull this, have everybody check out the layout/code/etc, then add the link to the main page when the gCal is set up? 
